### PR TITLE
added str methods to models and kwarg to allow empty manytomany fields.

### DIFF
--- a/Djeddit/models.py
+++ b/Djeddit/models.py
@@ -7,8 +7,19 @@ class Profile(models.Model):
     username = models.CharField(max_length=30)
     bio = models.CharField(max_length=300)
     karma = models.IntegerField()
-    subscriptions = models.ManyToManyField('Subreddit', related_name='sub_subscriptions')
-    moderators = models.ManyToManyField('Subreddit', related_name='mod_subscriptions')
+    subscriptions = models.ManyToManyField(
+        'Subreddit',
+        related_name='sub_subscriptions',
+        blank=True
+    )
+    moderators = models.ManyToManyField(
+        'Subreddit',
+        related_name='mod_subscriptions',
+        blank=True
+    )
+
+    def __str__(self):
+        return self.user.username
 
 
 class Subreddit(models.Model):
@@ -16,6 +27,9 @@ class Subreddit(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, blank=True)
     description = models.CharField(max_length=500)
     created_by = models.ForeignKey(Profile, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.name
 
 
 class Post(models.Model):
@@ -25,6 +39,9 @@ class Post(models.Model):
     profile_id = models.ForeignKey(Profile, on_delete=models.CASCADE)
     subreddit_id = models.ForeignKey(Subreddit, on_delete=models.CASCADE)
 
+    def __str__(self):
+        return self.content
+
 
 class Comment(models.Model):
     content = models.CharField(max_length=1000)
@@ -32,3 +49,6 @@ class Comment(models.Model):
     profile_id = models.ForeignKey(Profile, on_delete=models.CASCADE)
     post_id = models.ForeignKey(Post, on_delete=models.CASCADE)
     parent_id = models.IntegerField()
+
+    def __str__(self):
+        return self.content


### PR DESCRIPTION
# Description 
Model fields now have` __str__` methods, so they are represented correctly when displayed on the webpage. Likewise, `Manytomany` fields are now able to be empty/null when creating a new `Profile` from admin panel.

# Testing
From homepage, click on **_explore_** hyperlink. Then, click on **_testowesto_** hyperlink. Make sure nothing displays as an object.